### PR TITLE
Fix integer overflows with large files.

### DIFF
--- a/StinglePhotos/src/main/java/org/stingle/photos/Net/HttpsClient.java
+++ b/StinglePhotos/src/main/java/org/stingle/photos/Net/HttpsClient.java
@@ -338,7 +338,7 @@ public class HttpsClient {
 
 		String result = "";
 
-		int bytesRead, bytesAvailable, bufferSize;
+		int bytesRead;
 		byte[] buffer;
 		int maxBufferSize = 1024 * 1024;
 
@@ -408,16 +408,12 @@ public class HttpsClient {
 
 				outputStream.writeBytes(lineEnd);
 
-				bytesAvailable = fileInputStream.available();
-				bufferSize = Math.min(bytesAvailable, maxBufferSize);
-				buffer = new byte[bufferSize];
+				buffer = new byte[maxBufferSize];
 
-				bytesRead = fileInputStream.read(buffer, 0, bufferSize);
+				bytesRead = fileInputStream.read(buffer, 0, maxBufferSize);
 				while (bytesRead > 0) {
-					outputStream.write(buffer, 0, bufferSize);
-					bytesAvailable = fileInputStream.available();
-					bufferSize = Math.min(bytesAvailable, maxBufferSize);
-					bytesRead = fileInputStream.read(buffer, 0, bufferSize);
+					outputStream.write(buffer, 0, bytesRead);
+					bytesRead = fileInputStream.read(buffer, 0, maxBufferSize);
 				}
 
 				outputStream.writeBytes(lineEnd);

--- a/StinglePhotos/src/main/java/org/stingle/photos/Video/StingleDataSource.java
+++ b/StinglePhotos/src/main/java/org/stingle/photos/Video/StingleDataSource.java
@@ -82,7 +82,7 @@ public class StingleDataSource implements DataSource {
 			long chunkOffset = header.overallHeaderSize;
 			if(dataSpec.absoluteStreamPosition > 0){
 				currentChunkNumber = (int) Math.floor(dataSpec.absoluteStreamPosition / header.chunkSize) + 1;
-				chunkOffset = header.overallHeaderSize +  (currentChunkNumber - 1) * (AEAD.XCHACHA20POLY1305_IETF_NPUBBYTES + header.chunkSize + AEAD.XCHACHA20POLY1305_IETF_ABYTES);
+				chunkOffset = header.overallHeaderSize +  (long)(currentChunkNumber - 1) * (AEAD.XCHACHA20POLY1305_IETF_NPUBBYTES + header.chunkSize + AEAD.XCHACHA20POLY1305_IETF_ABYTES);
 
 				positionInChunk = (int)(dataSpec.absoluteStreamPosition - ((currentChunkNumber-1) * header.chunkSize));
 			}


### PR DESCRIPTION
This change allows files larger than 2 GB to be uploaded and played
back correctly (if they're videos).

HttpsClient.multipartUpload() relied on FileInputStream.available() to
calculate the amount of data to read. Unfortunately, available() can
return a negative value when files are larger than 2 GB. The fix is to
simply not use it.

StingleDataSource.open() had an integer overflow in the calculation for
chunkOffset. Added an explicit cast to long.